### PR TITLE
Dancer2 versions start from 0, not 2

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,4 +11,4 @@ AutoMetaResources.bugtracker.github = user:dagolden
 stopwords = AES
 
 [Prereqs]
-Dancer2 = 2
+Dancer2 = 0


### PR DESCRIPTION
Dancer2 is current at 0.04, so the prereq listed can't be met.
