### PR TITLE
Remove context usage:

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,7 +5,11 @@ Revision history for Dancer2-Session-Cookie
 
  [BUG FIXES]
 
- [DOCUMENTATION]
+ [CHANGED]
+
+ - Update for Dancer2 >= 1.143000.
+ - Requires Session::Storage::Secure 0.010 to allow storing objects,
+   which is specially relevant to JSON::bool data.
 
  [ENHANCEMENTS]
 

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -197,12 +197,12 @@ for my $c (@configs) {
 
             get '/destroy_session' => sub {
                 my $name = session('name') || '';
-                context->destroy_session;
+                app->destroy_session;
                 return "destroyed='$name'";
             };
 
             get '/churn_session' => sub {
-                context->destroy_session;
+                app->destroy_session;
                 session name => 'damian';
                 return "churned";
             };


### PR DESCRIPTION
Without the context object, you need to call the App to destroy the
current session.